### PR TITLE
Refactored some pieces - see below.

### DIFF
--- a/src/main/java/attune/client/AttuneClient.java
+++ b/src/main/java/attune/client/AttuneClient.java
@@ -218,23 +218,7 @@ public class AttuneClient implements RankingClient  {
      * @param authToken authentication token
      */
     public RankedEntities getRankings(RankingParams rankingParams, String authToken) throws ApiException {
-        int counter = 0;
-        RankedEntities retVal;
-
-        while (true) {
-            try {
-            	retVal = new GetRankingsHystrixCommand(entities, rankingParams, authToken).execute();
-                break;
-            } catch (HystrixRuntimeException ex) {
-                ++counter;
-                if (counter > MAX_RETRIES) {
-                    if (attuneConfigurable.isFallBackToDefault()) {
-                       // return returnDefaultRankings(rankingParams, ex.getCode());
-                    }
-                    throw ex;
-                }
-            }
-        }
+        RankedEntities retVal = new GetRankingsHystrixCommand(entities, rankingParams, authToken).execute();
         return retVal;
     }
 

--- a/src/main/java/attune/client/HystrixConfig.java
+++ b/src/main/java/attune/client/HystrixConfig.java
@@ -12,7 +12,7 @@ import com.google.common.collect.Maps;
  */
 public class HystrixConfig {
 
-	private static final String HYSTRIX_GROUP_NAME = "attune-client";
+	public static final String HYSTRIX_GROUP_NAME = "attune-client";
 	private final Map<String, Object> params;
 
 	private HystrixConfig(Map<String, Object> params) {

--- a/src/main/java/attune/client/hystrix/BindHystrixCommand.java
+++ b/src/main/java/attune/client/hystrix/BindHystrixCommand.java
@@ -3,18 +3,18 @@ package attune.client.hystrix;
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
 
+import attune.client.HystrixConfig;
 import attune.client.api.Anonymous;
 import attune.client.model.Customer;
 
 public class BindHystrixCommand extends HystrixCommand<Void> {
-	private static final String GROUP_NAME = "attune-client";
 	private final String anonymous;
 	private final Customer request;
 	private final String accessToken;
 	private final Anonymous anon;
 
 	public BindHystrixCommand(Anonymous anon, String anonymous, Customer request, String accessToken) {
-		super(HystrixCommandGroupKey.Factory.asKey(GROUP_NAME));
+		super(HystrixCommandGroupKey.Factory.asKey(HystrixConfig.HYSTRIX_GROUP_NAME));
 		this.anon = anon;
 		this.anonymous = anonymous;
 		this.request = request;

--- a/src/main/java/attune/client/hystrix/CreateAnonymousHystrixCommand.java
+++ b/src/main/java/attune/client/hystrix/CreateAnonymousHystrixCommand.java
@@ -1,5 +1,6 @@
 package attune.client.hystrix;
 
+import attune.client.HystrixConfig;
 import attune.client.api.Anonymous;
 import attune.client.model.AnonymousResult;
 import com.netflix.hystrix.HystrixCommand;
@@ -9,13 +10,12 @@ import com.netflix.hystrix.HystrixCommandGroupKey;
  * Created by sudnya on 10/22/15.
  */
 public class CreateAnonymousHystrixCommand extends HystrixCommand<AnonymousResult> {
-    private static final String GROUP_NAME = "attune-client";
     private final String accessToken;
     private final Anonymous anon;
 
     public CreateAnonymousHystrixCommand(Anonymous anon, String accessToken) {
-        super(HystrixCommandGroupKey.Factory.asKey(GROUP_NAME));
-        this.anon        = anon;
+    	super(HystrixCommandGroupKey.Factory.asKey(HystrixConfig.HYSTRIX_GROUP_NAME));
+		this.anon        = anon;
         this.accessToken = accessToken;
     }
 

--- a/src/main/java/attune/client/hystrix/GetBoundCustomerHystrixCommand.java
+++ b/src/main/java/attune/client/hystrix/GetBoundCustomerHystrixCommand.java
@@ -1,5 +1,6 @@
 package attune.client.hystrix;
 
+import attune.client.HystrixConfig;
 import attune.client.api.Anonymous;
 import attune.client.model.Customer;
 import com.netflix.hystrix.HystrixCommand;
@@ -9,14 +10,13 @@ import com.netflix.hystrix.HystrixCommandGroupKey;
  * Created by sudnya on 10/22/15.
  */
 public class GetBoundCustomerHystrixCommand extends HystrixCommand<Customer> {
-    private static final String GROUP_NAME = "attune-client";
     private final String anonymousId;
     private final String accessToken;
     private final Anonymous anon;
 
     public GetBoundCustomerHystrixCommand(Anonymous anon, String anonymousId, String accessToken) {
-        super(HystrixCommandGroupKey.Factory.asKey(GROUP_NAME));
-        this.anon        = anon;
+    	super(HystrixCommandGroupKey.Factory.asKey(HystrixConfig.HYSTRIX_GROUP_NAME));
+		this.anon        = anon;
         this.anonymousId = anonymousId;
         this.accessToken = accessToken;
     }

--- a/src/main/java/attune/client/hystrix/GetRankingsHystrixCommand.java
+++ b/src/main/java/attune/client/hystrix/GetRankingsHystrixCommand.java
@@ -2,20 +2,22 @@ package attune.client.hystrix;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
+import com.netflix.hystrix.exception.HystrixRuntimeException;
 
+import attune.client.AttuneClient;
+import attune.client.HystrixConfig;
 import attune.client.api.Entities;
 import attune.client.model.RankedEntities;
 import attune.client.model.RankingParams;
 
 public class GetRankingsHystrixCommand extends HystrixCommand<RankedEntities> {
-	private static final String GROUP_NAME = "attune-client";
 
 	private final Entities entities;
 	private final RankingParams params;
 	private final String accessToken;
 
 	public GetRankingsHystrixCommand(Entities entities, RankingParams params, String accessToken) {
-		super(HystrixCommandGroupKey.Factory.asKey(GROUP_NAME));
+		super(HystrixCommandGroupKey.Factory.asKey(HystrixConfig.HYSTRIX_GROUP_NAME));
 		this.entities = entities;
 		this.params = params;
 		this.accessToken = accessToken;
@@ -23,7 +25,21 @@ public class GetRankingsHystrixCommand extends HystrixCommand<RankedEntities> {
 
 	@Override
 	protected RankedEntities run() throws Exception {
-		return entities.getRankings(this.params, this.accessToken);
+		int counter = 0;
+		RankedEntities retVal;
+
+        while (true) {
+            try {
+            	retVal = entities.getRankings(params, accessToken);
+                break;
+            } catch (HystrixRuntimeException ex) {
+                ++counter;
+                if (counter > AttuneClient.MAX_RETRIES) {
+                    throw ex;
+                }
+            }
+        }
+        return retVal;
 	}
 
 	@Override

--- a/src/main/java/attune/client/hystrix/GetRankingsHystrixCommand.java
+++ b/src/main/java/attune/client/hystrix/GetRankingsHystrixCommand.java
@@ -2,8 +2,8 @@ package attune.client.hystrix;
 
 import com.netflix.hystrix.HystrixCommand;
 import com.netflix.hystrix.HystrixCommandGroupKey;
-import com.netflix.hystrix.exception.HystrixRuntimeException;
 
+import attune.client.ApiException;
 import attune.client.AttuneClient;
 import attune.client.HystrixConfig;
 import attune.client.api.Entities;
@@ -32,7 +32,7 @@ public class GetRankingsHystrixCommand extends HystrixCommand<RankedEntities> {
             try {
             	retVal = entities.getRankings(params, accessToken);
                 break;
-            } catch (HystrixRuntimeException ex) {
+            } catch (ApiException ex) {
                 ++counter;
                 if (counter > AttuneClient.MAX_RETRIES) {
                     throw ex;


### PR DESCRIPTION
- proposing a non singleton implementation
- remove double invocation on getRankings api from AttuneClient.  This needs to be done for all other apis
- moved retry logic to within Hystrix.  Ideally we should make this a concern of the http client layer.  once we get to refactoring the jersey-client -> http layer we should consider making that change
